### PR TITLE
Ex 1.3: fix largest-sums

### DIFF
--- a/sicp.rkt
+++ b/sicp.rkt
@@ -2,10 +2,16 @@
 (require (lib "trace.ss"))
 
 (define (square x) (* x x))
+(define (max a b)
+  (if (> a b)
+      a
+      b))
+(define (min a b)
+  (if (< a b)
+      a
+      b))
 (define (largest-sums x y z)
-  (+
-   (if (> x y) (square x) (square y))
-   (if (> y z) (square y) (square z))))
+  (+ (square (max x y)) (square (max (min x y) z))))
 
 (define (inc a) (+ a 1))
 (define (dec a) (- a 1))


### PR DESCRIPTION
Hi,
your guide has been very helpful to get started with SICP. However, I noticed a small bug in the solution to one of the first exercises.

```
(largest-sums 1 2 3)      ;13
(largest-sums 3 2 1)      ;13
(largest-sums 2 3 1)      ;13 --> was 18 before
```